### PR TITLE
[doc] Update severity binary flags

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -462,14 +462,13 @@ Flags:
  */
 enum SeverityFlag
 {
-	SeverityFlagDowntime = 1,
-	SeverityFlagAcknowledgement = 2,
-	SeverityFlagHostDown = 4,
-	SeverityFlagUnhandled = 8,
 	SeverityFlagPending = 16,
 	SeverityFlagWarning = 32,
 	SeverityFlagUnknown = 64,
 	SeverityFlagCritical = 128,
+	SeverityFlagDowntime = 256,
+	SeverityFlagAcknowledgement = 512,
+	SeverityFlagHostDown = 1024
 };
 ```
 


### PR DESCRIPTION
This PR updates the severity binary flags listed in documentation according to the `Service::GetSeverity()` function source code defined in https://github.com/Icinga/icinga2/blob/ee705bb110e802f8cafd21bab2d8697b0a538b0a/lib/icinga/service.cpp#L112

severity 288 -> 000100100000 -> warning with downtime
severity 2080 ->100000100000 -> warning without downtime
etc.